### PR TITLE
Telemetry: metric naming standards doc

### DIFF
--- a/specs/capri/Metric_Naming_Standards.md
+++ b/specs/capri/Metric_Naming_Standards.md
@@ -1,21 +1,28 @@
 # OpenSDS metric Naming standards  
+
 OpenSDS has different sources to generate metrics for Prometheus. Sources are in the form of exporters or adapters. Here we are defining a standard of forming metric name and labels from the metricSpec structure.
+
 ### metric spec structure 
+
 model.MetricSpec{
 			InstanceID,
 			InstanceName,
-			Job",
+			Job,
 			Associator,
-			Source",
+			Source,
 			Component,
 			Name,
 			Unit,
 			IsAggregated,
 			MetricValues[]{timestamp,value},
 		}
+		
 ### metric name format
+
 MetricSpec.Job_MetricSpec.Component_MetricSpec.Name_MetricSpec.unit
 Example:OpensSDS_Volume_ResponseTime_ms
+
 ### metric label format
+  
   {"instanceID":MetricSpecInstanceID.,"device":MetricSpec.InstanceName,"source":MetricSpec.Source}
 Example: {device="sda",instanceID="sda",source="Node"}

--- a/specs/capri/Metric_Naming_Standards.md
+++ b/specs/capri/Metric_Naming_Standards.md
@@ -8,21 +8,20 @@ model.MetricSpec{
 			InstanceID,
 			InstanceName,
 			Job,
-			Associator,
-			Source,
+			Labels,
 			Component,
 			Name,
 			Unit,
-			IsAggregated,
+			Aggr_type,
 			MetricValues[]{timestamp,value},
 		}
 		
 ### metric name format
 
-MetricSpec.Job_MetricSpec.Component_MetricSpec.Name_MetricSpec.unit
+MetricSpec.Job_MetricSpec.Component_MetricSpec.Name_MetricSpec.unit_<Aggr_type>
 Example:OpensSDS_Volume_ResponseTime_ms
 
 ### metric label format
   
-  {"instanceID":MetricSpecInstanceID.,"device":MetricSpec.InstanceName,"source":MetricSpec.Source}
-Example: {device="sda",instanceID="sda",source="Node"}
+  Labels will go as map[string]string in the Labels map.
+Example: {device="sda"}

--- a/specs/capri/Metric_Naming_Standards.md
+++ b/specs/capri/Metric_Naming_Standards.md
@@ -1,0 +1,21 @@
+# OpenSDS metric Naming standards  
+OpenSDS has different sources to generate metrics for Prometheus. Sources are in the form of exporters or adapters. Here we are defining a standard of forming metric name and labels from the metricSpec structure.
+### metric spec structure 
+model.MetricSpec{
+			InstanceID,
+			InstanceName,
+			Job",
+			Associator,
+			Source",
+			Component,
+			Name,
+			Unit,
+			IsAggregated,
+			MetricValues[]{timestamp,value},
+		}
+### metric name format
+MetricSpec.Job_MetricSpec.Component_MetricSpec.Name_MetricSpec.unit
+Example:OpensSDS_Volume_ResponseTime_ms
+### metric label format
+  {"instanceID":MetricSpecInstanceID.,"device":MetricSpec.InstanceName,"source":MetricSpec.Source}
+Example: {device="sda",instanceID="sda",source="Node"}


### PR DESCRIPTION
This is the guide for developers who develop Adapters,exportes,APIs for metric handling.
OpenSDS has different sources to generate metrics for prometheus.Sources are in the form of exporters or adapters. Here we are defining a standerd of forming metric name an label from the metricpec structure.